### PR TITLE
Update atprk_hardlightshield.activeitem

### DIFF
--- a/items/active/shields/atprk_hardlightshield.activeitem
+++ b/items/active/shields/atprk_hardlightshield.activeitem
@@ -1,6 +1,6 @@
 {
   "itemName" : "atprk_hardlightshield",
-  "fixedLevel" : false,
+  "level" : 7,
   "price" : 1750,
   "maxStack" : 1,
   "rarity" : "Legendary",


### PR DESCRIPTION
fixed how the Ancient Light Shield was effectively set to tier one and set it to tier 7 since it's post-ruin