### PR TITLE
proposal to make Ruined planets tier 8 as opposed to tier 6

### DIFF
--- a/terrestrial_worlds.config.patch
+++ b/terrestrial_worlds.config.patch
@@ -56,7 +56,7 @@
     "op" : "add",
     "path" : "/planetTypes/atprk_ruinedworld",
     "value" : {
-      "threatRange" : [6, 6],
+      "threatRange" : [8, 8],
       "layers" : {
         "surface" : {
           "primaryRegion" : ["atprk_ruinedworld"]


### PR DESCRIPTION
I figured that it'd make sense that as a (presumably) post end game planet, Ruined planets would be of the same tier that both Ancient Vaults and the Biotyrant set is, which is tier 8