### PR TITLE
Proposal to rename Boiling Oceans to just Boiling planets for consistency's sake, part 1

### DIFF
--- a/interface/cockpit/cockpit.config.patch
+++ b/interface/cockpit/cockpit.config.patch
@@ -12,7 +12,7 @@
     {
       "op" : "add",
       "path" : "/planetTypeNames/atprk_boilingocean",
-      "value" : "Boiling Ocean"
+      "value" : "Boiling"
     },
     {
       "op" : "add",


### PR DESCRIPTION
Worth noting that none of the vanilla oceanic planet types are literally named with ocean as a postfix :P