### PR TITLE
proposal to replace glowing rain with the unused ashfall weather

### DIFF
--- a/weather.config.patch
+++ b/weather.config.patch
@@ -16,7 +16,7 @@
 		"value" : [
 			[0.75, "clear"],
 			[0.22, "lightash"],
-			[0.03, "glowingrain"]
+			[0.03, "ash"]
 		]
 	},
 	{


### PR DESCRIPTION
I think it'd make for a fitting weather effect to use on ashy planets, don't you think? It's pretty much a heavier version of light ashfall, placing down entire ash blocks rather than just a small layer