### PR TITLE
Tweak for Ruined planets

### DIFF
--- a/terrestrial_worlds.config.patch
+++ b/terrestrial_worlds.config.patch
@@ -56,7 +56,7 @@
     "op" : "add",
     "path" : "/planetTypes/atprk_ruinedworld",
     "value" : {
-      "threatRange" : [8, 8],
+      "threatRange" : [7, 7],
       "layers" : {
         "surface" : {
           "primaryRegion" : ["atprk_ruinedworld"]


### PR DESCRIPTION
As it turns out, the game only supports up to tier 7 with planets, a bit unfortunate, but ah well.