### PR TITLE
Proposal to switch this over to the Hylotl Relic Collector

### DIFF
--- a/recipes/atprk_relicexchange/atprk_erchiusspook.recipe
+++ b/recipes/atprk_relicexchange/atprk_erchiusspook.recipe
@@ -32,5 +32,5 @@
       ]
     }
   },
-  "groups" : [ "atprk_relicexchange", "atprk_relicexchange_novakid", "nouncrafting" ]
+  "groups" : [ "atprk_relicexchange", "atprk_relicexchange_hylotl", "nouncrafting" ]
 }


### PR DESCRIPTION
Given the Noolith connection the Erchius Spook has, I think it'd make more sense if it was from the Hylotl Relic Collector perhaps. That would mean however that the Novakid Relic Collector would only have two unique wares, but it a way it kinda makes sense in a funny way with how the Relic Seekers are an overwhelmingly Novakid organization.