### PR TITLE
Proposal to add full Cultist set to the Occasus Warehouse

### DIFF
--- a/objects/mission/atprk_metamorphosishallnpcs/atprk_cultistpropshop/atprk_cultistpropshop.object
+++ b/objects/mission/atprk_metamorphosishallnpcs/atprk_cultistpropshop/atprk_cultistpropshop.object
@@ -25,6 +25,9 @@
       { "item" : "cultistdoor" },
       { "item" : "cultistairlockbossdoor" },
       { "item" : "cultistairlockhatch" },
+      { "item" : "cultisthead" },
+      { "item" : "cultistchest" },
+      { "item" : "cultistlegs" },
       { "item" : { "name" : "atprk_betacultisthood" }, "prerequisiteQuest" : "atprk_betastarmapquest" }
     ]
   },


### PR DESCRIPTION
Considering how rare the Cultist set is (each piece has only a 1% chance of dropping from Cultists after all), figured it'd be nice to make it easier to obtain through this object here. Also makes sense given the presence of the Oldschool Culstist Hood item as well