### PR TITLE
Proposal to increase tier of Pixie Wand

### DIFF
--- a/items/active/weapons/wand/atprk_pixiewand.activeitem
+++ b/items/active/weapons/wand/atprk_pixiewand.activeitem
@@ -1,6 +1,6 @@
 {
   "itemName" : "atprk_pixiewand",
-  "level" : 2,
+  "level" : 4,
   "price" : 750,
   "maxStack" : 1,
   "rarity" : "Legendary",


### PR DESCRIPTION
Given that the tenant required to obtain this wand requires objects from a tier 3 planet, I figure it'd make more sense for the wand itself to be tier 4 like any unique weapons found on tier 3 planets, this also has the effect of buffing it too of course.