### PR TITLE
proposal to add ambience to Chthonian Swamp biome

### DIFF
--- a/biomes/surface/atprk_chthonianswamp.biome
+++ b/biomes/surface/atprk_chthonianswamp.biome
@@ -30,6 +30,15 @@
 
   "parallax" : "/parallax/surface/moon.parallax",
 
+  "ambientNoises" : {
+    "day" : {
+      "tracks" : [ "/sfx/environmental/moon_surface.ogg" ]
+    },
+    "night" : {
+      "tracks" : [ "/sfx/environmental/moon_surface.ogg" ]
+    }
+  },
+
   "surfacePlaceables" : {
     "grassMod" : [ "metal" ],
     "grassModDensity" : 0.4,


### PR DESCRIPTION
Unless the lack of ambience is intentional, it seems kinda jarring just having all the ambience cut out when the player enters a Chthonian Swamp