### PR TITLE
Add atprk_ancientdockingfieldlit.frames

### DIFF
--- a/objects/atprk_ancient/atprk_ancientdockingfield/atprk_ancientdockingfieldlit.frames
+++ b/objects/atprk_ancient/atprk_ancientdockingfield/atprk_ancientdockingfieldlit.frames
@@ -1,0 +1,31 @@
+{
+  "frameGrid" : {
+    "size" : [8, 96],
+    "dimensions" : [16, 1],
+    "names" : [
+      [ "idle1", "idle2", "idle3", "idle4", "idle5", "idle6", "idle7", "idle8", "detected1", "detected2", "detected3", "detected4", "detected5", "detected6", "detected7", "detected8" ]
+    ]
+  },
+
+  "aliases" : {
+    "default.off" : "idle1",
+    "default.on" : "detected1",
+    "off.1" : "idle1",
+    "off.2" : "idle2",
+    "off.3" : "idle3",
+    "off.4" : "idle4",
+    "off.5" : "idle5",
+    "off.6" : "idle6",
+    "off.7" : "idle7",
+    "off.8" : "idle8",
+    "on.1" : "detected1",
+    "on.2" : "detected2",
+    "on.3" : "detected3",
+    "on.4" : "detected4",
+    "on.5" : "detected5",
+    "on.6" : "detected6",
+    "on.7" : "detected7",
+    "on.8" : "detected8"
+  }
+}
+  


### PR DESCRIPTION
Add atprk_ancientdockingfieldlit.frames to fix the following error:

[11:22:37.757] [Error] Exception caught loading asset: /objects/atprk_ancient/atprk_ancientdockingfield/atprk_ancientdockingfieldlit.png:off.1, (AssetException) No such frame off.1 in frames spec /default.frames

...which then caused further errors:

[11:22:37.924] [Error] UniverseServer: error during world create: (WorldServerException) Exception encountered initializing world
...
Caused by: (DungeonException) Error generating dungeon named 'atprk_infinitemazealtalt'
...
Caused by: (AssetException) Error loading asset /objects/atprk_ancient/atprk_ancientdockingfield/atprk_ancientdockingfieldlit.png:off.1