### PR TITLE
Update atprk_relicsearchquestcomplete.cinematic

### DIFF
--- a/cinematics/atprk_relicsearchquestcomplete.cinematic
+++ b/cinematics/atprk_relicsearchquestcomplete.cinematic
@@ -260,7 +260,12 @@
       "loops" : -1,
       "resource" : "/sfx/interface/aichatter1_loop.ogg"
     },
-
+    {
+      "timecode" : 31.5,
+      "endTimecode" : 35.5,
+      "loops" : 0,
+      "resource" : "/sfx/instruments/drumkit/52.ogg"
+    },
     {
       "timecode" : 1.0,
       "endTimecode" : 31.5,


### PR DESCRIPTION
Just a small improvement to make the end of the cutscene less abrupt audio-wise, probably should adjust the chatter timecodes to ensure that they line up better to their animations in the future too