### PR TITLE
Update atprk_mechbodydevout.recipe

### DIFF
--- a/recipes/mech/body/atprk_mechbodydevout.recipe
+++ b/recipes/mech/body/atprk_mechbodydevout.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "durasteelbar", "count" : 20 },
+    { "item" : "titaniumbar", "count" : 20 },
     { "item" : "salvagebody", "count" : 10 },
     { "item" : "salvagetier4", "count" : 5 }
   ],


### PR DESCRIPTION
The Occasus mech body in vanilla uses the incorrect bar material for its tier, hence why this mech part has been adjusted to use titanium instead