### PR TITLE
Proposal to make Feral Morningstar tier 4

### DIFF
--- a/items/active/weapons/whip/atprk_fenronwhip.activeitem
+++ b/items/active/weapons/whip/atprk_fenronwhip.activeitem
@@ -1,7 +1,7 @@
 {
   "itemName" : "atprk_fenronwhip",
   "price" : 1000,
-  "level" : 6,
+  "level" : 4,
   "maxStack" : 1,
   "rarity" : "Rare",
   "description" : "An antique weapon of Fenron origin.",


### PR DESCRIPTION
Obviously this would necessitate an upgraded version of it, but considering that the player is expected/most likely to encounter the Hunger Grove (and therefore the materials needed to obtain the Morningstar) at tier 4, it follows that the Fenron weapon would be a tier 4 one instead of a tier 6 for balancing purposes.